### PR TITLE
Add Swagger/OpenAPI documentation for backend APIs

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 import logging
+from flasgger import Swagger
 
 # ---------------- Logging Configuration ----------------
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -36,6 +37,25 @@ app.config['UPLOAD_FOLDER'] = os.path.join(BASE_DIR, 'uploads')
 app.config['BUILD_FOLDER'] = os.path.join(BASE_DIR, 'builds')
 app.config['FLUTTER_TEMPLATE'] = os.path.join(BASE_DIR, 'templates', 'webview_app')
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB max file size
+# ---------------- Swagger Configuration ----------------
+
+swagger_config = {
+    "headers": [],
+    "specs": [
+        {
+            "endpoint": "apispec",
+            "route": "/apispec.json",
+            "rule_filter": lambda rule: True,
+            "model_filter": lambda tag: True,
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+    "swagger_ui": True,
+    "specs_route": "/apidocs/",
+}
+
+Swagger(app, config=swagger_config)
+
 # ---------------- Global Error Handlers ----------------
 
 @app.errorhandler(Exception)
@@ -747,6 +767,51 @@ def serve_upload(filename):
 
 @app.route('/api/build', methods=['POST'])
 def start_build():
+
+    """
+    Start a new build process
+    ---
+    tags:
+      - Build
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          required:
+            - app_name
+            - app_version
+            - build_number
+            - web_url
+            - platforms
+          properties:
+            app_name:
+              type: string
+            app_version:
+              type: string
+            build_number:
+              type: string
+            web_url:
+              type: string
+            platforms:
+              type: array
+              items:
+                type: string
+    responses:
+      200:
+        description: Build started successfully
+      400:
+        description: Invalid input
+      500:
+        description: Internal server error
+    """
+
+
     try:
         logger.info("Received build request")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask>=3.0.0
 werkzeug>=3.0.0
 cryptography>=41.0.0
+flasgger


### PR DESCRIPTION
# Pull Request

## Description
This pull request adds Swagger/OpenAPI documentation to the SWAB backend to improve developer experience and API visibility.

## Related Issue
Closes #10 

## Proposed Changes
- Added Swagger/OpenAPI support using Flasgger
- Configured Swagger UI and API specification generation
- Documented the core `/api/build` endpoint with request schema and responses
- Exposed interactive API documentation at `/apidocs`

## Screenshots or GIFs
Swagger UI available at `/apidocs`.

## Testing
- Installed dependencies from `requirements.txt`
- Ran the application locally using `python app.py`
- Verified that Swagger UI loads at `/apidocs`
- Confirmed `/api/build` endpoint appears with correct request/response schema

## Additional Notes
This PR focuses only on API documentation and does not modify existing API behavior.

## Checklist
- [x] Code follows the project's coding conventions and style guidelines.
- [x] Code has been tested thoroughly.
- [ ] Documentation has been updated, if applicable.
- [x] All existing tests pass successfully.
- [ ] New tests have been added to cover the changes, if applicable.
- [x] Commit messages are clear and descriptive.

By submitting this pull request, I confirm that my contribution is made under the project's [license](LICENSE).
