### PR TITLE
Add CLI tool for headless builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask>=3.0.0
 werkzeug>=3.0.0
 cryptography>=41.0.0
 flasgger
+requests

--- a/swab_cli.py
+++ b/swab_cli.py
@@ -1,0 +1,69 @@
+import argparse
+import sys
+import requests
+
+API_URL = "http://127.0.0.1:5000/api/build"
+ALLOWED_PLATFORMS = {"android", "ios", "windows", "mac", "linux"}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="SWAB CLI - Trigger headless builds"
+    )
+
+    parser.add_argument("--app-name", required=True)
+    parser.add_argument("--app-description", required=True)
+    parser.add_argument("--app-version", required=True)
+    parser.add_argument("--build-number", required=True)
+    parser.add_argument("--package-name", required=True)
+    parser.add_argument("--web-url", required=True)
+
+    parser.add_argument(
+        "--platforms",
+        nargs="+",
+        required=True,
+        help="Target platforms (android ios windows mac linux)"
+    )
+
+    return parser.parse_args()
+
+
+def validate_platforms(platforms):
+    invalid = [p for p in platforms if p not in ALLOWED_PLATFORMS]
+    if invalid:
+        print(f"Error: Unsupported platform(s): {', '.join(invalid)}")
+        sys.exit(1)
+
+
+def main():
+    args = parse_args()
+    validate_platforms(args.platforms)
+
+    payload = {
+        "app_name": args.app_name,
+        "app_description": args.app_description,
+        "app_version": args.app_version,
+        "build_number": args.build_number,
+        "package_name": args.package_name,
+        "web_url": args.web_url,
+        "platforms": args.platforms,
+    }
+
+    try:
+        response = requests.post(API_URL, json=payload, timeout=10)
+    except requests.RequestException as e:
+        print(f"Failed to connect to backend: {e}")
+        sys.exit(1)
+
+    if response.status_code != 200:
+        print("Build request failed:")
+        print(response.text)
+        sys.exit(1)
+
+    data = response.json()
+    print("Build started successfully")
+    print(f"Build ID: {data.get('build_id')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request

## Description
This pull request introduces a simple Python-based CLI tool to trigger SWAB builds without using the web UI, enabling headless and automated build workflows.

## Related Issue
Closes #12

## Proposed Changes
- Added a Python CLI tool (`swab_cli.py`) to trigger builds from the command line
- Accepts required build parameters as command-line arguments
- Supports single and multiple platform builds
- Uses the existing `/api/build` backend API without modifying core build logic

## Screenshots or GIFs
Not applicable (CLI-based feature).

## Testing
- Ran the backend locally using `python app.py`
- Executed the CLI using `python swab_cli.py` with valid parameters
- Verified successful build initiation and returned build ID
- Tested validation for unsupported platforms

## Additional Notes
The CLI is intentionally minimal and designed as a thin wrapper over the existing backend API to support automation and scripting use cases.

## Checklist
- [x] Code follows the project's coding conventions and style guidelines.
- [x] Code has been tested thoroughly.
- [ ] Documentation has been updated, if applicable.
- [x] All existing tests pass successfully.
- [ ] New tests have been added to cover the changes, if applicable.
- [x] Commit messages are clear and descriptive.

By submitting this pull request, I confirm that my contribution is made under the project's [license](LICENSE).
